### PR TITLE
Refactor string formatting and update tests

### DIFF
--- a/ml_orchestrator/comp_parser.py
+++ b/ml_orchestrator/comp_parser.py
@@ -39,9 +39,15 @@ class ComponentParser:
         prams = ComponentParser.get_func_params(dec_vars, with_typing=False)
         override_params = ComponentParser._get_decorator_override_params(prams)
         dec_scope = "(\n\t" + ",\n\t".join(override_params) + "\n)"
-        dec_scope = dec_scope.replace(", '", ", f'").replace("['", "[f'")
+        dec_scope = ComponentParser.convert_to_format_str(dec_scope)
         func_definition = f"@component{dec_scope}"
         return func_definition
+
+    @staticmethod
+    def convert_to_format_str(text: str) -> str:
+        new_text = text.replace(", '", ", f'").replace("['", "[f'")
+        new_text = new_text.replace(', "', ', f"').replace('["', '[f"')
+        return new_text
 
     @staticmethod
     def _get_decorator_override_params(prams: List[str]) -> List[str]:
@@ -60,7 +66,7 @@ class ComponentParser:
     @staticmethod
     def write_to_file(filename: str, content: str) -> None:
         file_content = f"{IMPORT_COMPOUND}\n\n\n{content}"
-        file_content = f"# flake8: noqa: F403, F405\n{file_content}"
+        file_content = f"# flake8: noqa: F403, F405, B006\n{file_content}"
         with open(filename, "w", encoding="utf-8") as f:
             f.write(file_content)
 

--- a/tests/dummy_components.py
+++ b/tests/dummy_components.py
@@ -33,7 +33,7 @@ class ComponentTestB(ComponentTestA):
         return EnvironmentParams(
             base_image="base_image",
             target_image="target_image",
-            packages_to_install=["packages_to_install", ""],
+            packages_to_install=["packages_to_install", "", "sd''{d}"],
             pip_index_urls=["pip_index_urls"],
             output_component_file="output_component_file",
             install_kfp_package=True,

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -48,7 +48,8 @@ def test_dec_op():
     assert "(\n\t\n)" not in str_func and "()" not in str_func
     assert "None" not in str_func
     for k, v in params.items():
-        assert str(v).replace(", '", ", f'").replace("['", "[f'") in str_func
+        parsed = ComponentParser.convert_to_format_str(str(v))
+        assert parsed in str_func
         assert k in str_func
 
 


### PR DESCRIPTION
Extracted string formatting logic into a standalone function in the comp_parser.py file for better code readability and maintainability. Amended flake8 comment to ignore warning B006. Updated the tests to use the new function and slightly adjusted dummy data.