### PR TITLE
Add import for ComponentParser, MetaComponent, and EnvironmentParams

### DIFF
--- a/tests/test_iso/test_iso.py
+++ b/tests/test_iso/test_iso.py
@@ -13,5 +13,6 @@ def test_kfp_not_installed():
 
 def test_import_orchestrator():
     # assert orchestrator is installed
+    from ml_orchestrator import ComponentParser, MetaComponent, EnvironmentParams  # noqa
 
     assert True


### PR DESCRIPTION
These imports ensure that the orchestrator components are available for testing. This change addresses potential missing dependencies during test execution by explicitly importing necessary modules.