### PR TITLE
Switch order of 'poetry check' in iso_test and add tests in publish

### DIFF
--- a/.github/workflows/iso_test.yml
+++ b/.github/workflows/iso_test.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: pipx install poetry
+      - run: poetry check
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - run: poetry install
-      - run: poetry check
       - run: poetry run pytest ./tests/test_iso
     continue-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
       - run: pipx install poetry
       - uses: actions/setup-python@v5
       - run: poetry install
+      - run: poetry run pytest ./tests/test_iso
+      - run: poetry install --all-extras
       - run: poetry run pytest
       - run: poetry version ${{ github.ref_name }}
       - run: poetry build


### PR DESCRIPTION
Reordered 'poetry check' command for clearer workflow in iso_test.yml. Added test execution and extra installs to publish.yml to ensure thorough validation before publishing.