### PR TITLE
Add return type handling for component execution

### DIFF
--- a/dummy_components/dummy_components.py
+++ b/dummy_components/dummy_components.py
@@ -44,3 +44,15 @@ class ComponentTestB(ComponentTestA):
 class ComponentTestC(ComponentTestB):
     def execute(self) -> int:  # type: ignore
         return 1
+
+
+@dataclasses.dataclass(unsafe_hash=True)
+class ComponentTestC2(ComponentTestB):
+    def execute(self) -> str:  # type: ignore
+        return "1"
+
+
+@dataclasses.dataclass(unsafe_hash=True)
+class ComponentTestC3(ComponentTestB):
+    def execute(self) -> bool:  # type: ignore
+        return False

--- a/dummy_components/dummy_components.py
+++ b/dummy_components/dummy_components.py
@@ -1,4 +1,4 @@
-import dataclasses
+from dataclasses import dataclass, field
 from typing import List
 
 from ml_orchestrator import EnvironmentParams
@@ -6,13 +6,13 @@ from ml_orchestrator.artifacts import Dataset, Input, Metrics, Model, Output
 from ml_orchestrator.meta_comp import MetaComponent
 
 
-@dataclasses.dataclass(unsafe_hash=True)
+@dataclass
 class MetaComponentTest(MetaComponent):
     def execute(self) -> None:
         pass
 
 
-@dataclasses.dataclass(unsafe_hash=True)
+@dataclass
 class ComponentTestA(MetaComponentTest):
     param_1: int = 1
     param_2: str = "1"
@@ -21,11 +21,12 @@ class ComponentTestA(MetaComponentTest):
     metrics: Output[Metrics] = None
 
 
-@dataclasses.dataclass(unsafe_hash=True)
+@dataclass
 class ComponentTestB(ComponentTestA):
     param_3: int = 2
     param_4: str = "2"
     param_list: List[int] = None
+
     model: Output[Model] = None
 
     @property
@@ -40,19 +41,36 @@ class ComponentTestB(ComponentTestA):
         )
 
 
-@dataclasses.dataclass(unsafe_hash=True)
+@dataclass
 class ComponentTestC(ComponentTestB):
     def execute(self) -> int:  # type: ignore
         return 1
 
 
-@dataclasses.dataclass(unsafe_hash=True)
+@dataclass
 class ComponentTestC2(ComponentTestB):
     def execute(self) -> str:  # type: ignore
         return "1"
 
 
-@dataclasses.dataclass(unsafe_hash=True)
+@dataclass
 class ComponentTestC3(ComponentTestB):
     def execute(self) -> bool:  # type: ignore
         return False
+
+
+@dataclass
+class ComponentTestD(ComponentTestB):
+    param_list_2: List[int] = field(default_factory=list)
+    param_list_3: List[int] = field(default_factory=lambda: [1, 2, 3])
+
+    def execute(self) -> None:
+        pass
+
+
+@dataclass
+class ComponentTestD2(ComponentTestB):
+    param_dict: dict = field(default_factory=dict)
+
+    def execute(self) -> None:
+        pass

--- a/dummy_components/protocol_components.py
+++ b/dummy_components/protocol_components.py
@@ -37,3 +37,21 @@ class ComponentTestB(ComponentTestA):
             install_kfp_package=True,
             kfp_package_path="kfp_package_path",
         )
+
+
+@dataclasses.dataclass(unsafe_hash=True)
+class ComponentTestC(ComponentTestB):
+    def execute(self) -> int:  # type: ignore
+        return 1
+
+
+@dataclasses.dataclass(unsafe_hash=True)
+class ComponentTestC2(ComponentTestB):
+    def execute(self) -> str:  # type: ignore
+        return "1"
+
+
+@dataclasses.dataclass(unsafe_hash=True)
+class ComponentTestC3(ComponentTestB):
+    def execute(self) -> bool:  # type: ignore
+        return False

--- a/ml_orchestrator/comp_protocol/func_parser.py
+++ b/ml_orchestrator/comp_protocol/func_parser.py
@@ -63,7 +63,7 @@ class FunctionParser:
         for field in fields:
             field_defaults = field.default if not field.default == dataclasses.MISSING else None
             field_has_default_factory = field.default_factory == dataclasses.MISSING
-            field_defaults = field.default_factory() if not field_has_default_factory and field_defaults else None
+            field_defaults = field.default_factory() if not field_has_default_factory and field_defaults else None  # type: ignore
             ins_vars[field] = field_defaults
 
         return ins_vars

--- a/ml_orchestrator/comp_protocol/func_parser.py
+++ b/ml_orchestrator/comp_protocol/func_parser.py
@@ -61,7 +61,10 @@ class FunctionParser:
         fields = dataclasses.fields(component)  # type: ignore
         ins_vars = dict()
         for field in fields:
-            ins_vars[field] = getattr(component, field.name)
+            field_defaults = field.default if not field.default == dataclasses.MISSING else None
+            field_has_default_factory = field.default_factory == dataclasses.MISSING
+            field_defaults = field.default_factory() if not field_has_default_factory and field_defaults else None
+            ins_vars[field] = field_defaults
 
         return ins_vars
 

--- a/ml_orchestrator/comp_protocol/func_parser.py
+++ b/ml_orchestrator/comp_protocol/func_parser.py
@@ -46,7 +46,7 @@ class FunctionParser:
         return comp_run
 
     @classmethod
-    def exe_return(cls, comp) -> Any:
+    def exe_return(cls, comp: Type[ComponentProtocol]) -> Any:
         execute_return_type = comp.execute.__annotations__.get("return")
         return execute_return_type
 

--- a/ml_orchestrator/comp_protocol/func_parser.py
+++ b/ml_orchestrator/comp_protocol/func_parser.py
@@ -30,17 +30,25 @@ class FunctionParser:
         kfp_func_name = comp_class.__name__.lower()
         func_scope = "(\n\t" + ",\n\t".join(self.get_func_params(component_variables)) + "\n)"
         comp_scope = "(\n\t\t" + ",\n\t\t".join(self.get_comp_params(component_variables)) + "\n\t)"
-        func_definition = f"def {kfp_func_name}{func_scope}:"
+        return_type = ""
+        if self.exe_return(comp_class) is not None:
+            return_type = f" -> {self.exe_return(comp_class).__name__}"
+
+        func_definition = f"def {kfp_func_name}{func_scope}{return_type}:"
         comp_init = f"comp = {comp_class.__name__}{comp_scope}"
         return comp_init, func_definition
 
     @classmethod
     def comp_execute(cls, comp: Type[ComponentProtocol]) -> str:
-        execute_return_type = comp.execute.__annotations__.get("return")
         comp_run = "comp.execute()"
-        if execute_return_type is not None:
+        if cls.exe_return(comp) is not None:
             comp_run = "return comp.execute()"
         return comp_run
+
+    @classmethod
+    def exe_return(cls, comp) -> Any:
+        execute_return_type = comp.execute.__annotations__.get("return")
+        return execute_return_type
 
     @staticmethod
     def get_func_params(comp_vars: Dict[dataclasses.Field, Any], with_typing: bool = True) -> List[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,8 @@ def fp(request):
         dcomps.ComponentTestC,
         dcomps.ComponentTestC2,
         dcomps.ComponentTestC3,
+        dcomps.ComponentTestD,
+        dcomps.ComponentTestD2,
         pcomps.ComponentTestB,
         pcomps.ComponentTestA,
         pcomps.ComponentTestC,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,13 @@ def fp(request):
         dcomps.ComponentTestB,
         dcomps.ComponentTestA,
         dcomps.ComponentTestC,
+        dcomps.ComponentTestC2,
+        dcomps.ComponentTestC3,
         pcomps.ComponentTestB,
         pcomps.ComponentTestA,
+        pcomps.ComponentTestC,
+        pcomps.ComponentTestC2,
+        pcomps.ComponentTestC3,
     ]
 )
 def dummy_component_class(request):

--- a/tests/test_write_to_file.py
+++ b/tests/test_write_to_file.py
@@ -19,6 +19,10 @@ def test_write_to_file_base(fp, dummy_component_class, tmp_files_folder):
     assert "from kfp.dsl import *" in file_content
     assert f"{comp_func_name}(" in file_content
     assert f"{name}(" in file_content
+    return_type = dummy_component_class.execute.__annotations__["return"]
+    if return_type is not None:
+        assert "return comp.execute()" in file_content
+        assert f"-> {return_type.__name__}:" in file_content
 
 
 @pytest.mark.parametrize("comp", [ComponentTestB(), ComponentTestA()])


### PR DESCRIPTION
Enhanced the function parser to include return type annotations in function definitions and component execution. This update ensures that the code accurately reflects the return types of components by adding the appropriate return annotations in both definition and execution contexts. Additionally, new test cases were added for components with different return types.