### PR TITLE
Refactor component parsing and update dependencies

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,10 +16,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: poetry
 
-#      - run: poetry install
-#      - run: poetry run pre-commit install
-#      - run: poetry run pre-commit run --all-files
-#      - run: poetry run mypy . --config-file pyproject.toml
+
       - run: make
       - run: make check
       - run: make mypy

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,7 +16,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: poetry
 
-      - run: poetry install
-      - run: poetry run pre-commit install
-      - run: poetry run pre-commit run --all-files
-      - run: poetry run mypy . --config-file pyproject.toml
+#      - run: poetry install
+#      - run: poetry run pre-commit install
+#      - run: poetry run pre-commit run --all-files
+#      - run: poetry run mypy . --config-file pyproject.toml
+      - run: make
+      - run: make check
+      - run: make mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: no-commit-to-branch
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.8.4
     hooks:
       - id: ruff-format
         args: [ --preview, --config=pyproject.toml ]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ default: install
 
 install:
 	poetry install --all-extras
-	poetry run pre-commit autoupdate
+#	poetry run pre-commit autoupdate
 	poetry run pre-commit install
 
 test:
@@ -12,3 +12,5 @@ test:
 
 check:
 	poetry run pre-commit run --all-files
+mypy:
+	poetry run mypy . --config-file pyproject.toml

--- a/dummy_components/__init__.py
+++ b/dummy_components/__init__.py
@@ -1,0 +1,39 @@
+from dummy_components import (
+    dummy_components as dcomps,
+    dummy_components_v2 as dv2comps,
+    invalid_protocol_components as ipcomps,
+    protocol_components as pcomps,
+)
+
+valid_classes_meta = [
+    dcomps.ComponentTestB,
+    dcomps.ComponentTestA,
+    dcomps.ComponentTestC,
+    dcomps.ComponentTestC2,
+    dcomps.ComponentTestC3,
+    dcomps.ComponentTestD,
+    dcomps.ComponentTestD2,
+]
+valid_classes_meta_v2 = [
+    dv2comps.ComponentTestB,
+    dv2comps.ComponentTestA,
+    dv2comps.ComponentTestC,
+    dv2comps.ComponentTestC2,
+    dv2comps.ComponentTestC3,
+    dv2comps.ComponentTestD,
+    dv2comps.ComponentTestD2V2,
+]
+valid_classes_protocol = [
+    pcomps.ComponentTestB,
+    pcomps.ComponentTestA,
+    pcomps.ComponentTestC,
+    pcomps.ComponentTestC2,
+    pcomps.ComponentTestC3,
+]
+invalid_classes_protocols = [
+    ipcomps.ComponentTestB,
+    ipcomps.ComponentTestA,
+]
+
+
+valid_classes = valid_classes_meta + valid_classes_meta_v2 + valid_classes_protocol + valid_classes_meta_v2

--- a/dummy_components/dummy_components_v2.py
+++ b/dummy_components/dummy_components_v2.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from ml_orchestrator import EnvironmentParams
+from ml_orchestrator.artifacts import Dataset, Input, Metrics, Model, Output
+from ml_orchestrator.meta_comp import MetaComponentV2
+
+
+@dataclass
+class MetaComponentTest(MetaComponentV2):
+    def execute(self) -> None:
+        pass
+
+    @classmethod
+    def env(cls) -> EnvironmentParams:
+        return EnvironmentParams()
+
+
+@dataclass
+class ComponentTestA(MetaComponentTest):
+    param_1: int = 1
+    param_2: str = "1"
+    artifact: Input[Dataset] = None
+    out_artifact: Output[Dataset] = None
+    metrics: Output[Metrics] = None
+
+
+@dataclass
+class ComponentTestB(ComponentTestA):
+    param_3: int = 2
+    param_4: str = "2"
+    param_list: List[int] = None
+
+    model: Output[Model] = None
+
+    @classmethod
+    def env(cls) -> EnvironmentParams:
+        return EnvironmentParams(
+            base_image="base_image",
+            target_image="target_image",
+            packages_to_install=["packages_to_install", "", "sd''{d}"],
+            pip_index_urls=["pip_index_urls"],
+            install_kfp_package=True,
+            kfp_package_path="kfp_package_path",
+        )
+
+
+@dataclass
+class ComponentTestC(ComponentTestB):
+    def execute(self) -> int:  # type: ignore
+        return 1
+
+
+@dataclass
+class ComponentTestC2(ComponentTestB):
+    def execute(self) -> str:  # type: ignore
+        return "1"
+
+
+@dataclass
+class ComponentTestC3(ComponentTestB):
+    def execute(self) -> bool:  # type: ignore
+        return False
+
+
+@dataclass
+class ComponentTestD(ComponentTestB):
+    param_list_2: List[int] = field(default_factory=list)
+    param_list_3: List[int] = field(default_factory=lambda: [1, 2, 3])
+
+    def execute(self) -> None:
+        pass
+
+
+@dataclass
+class ComponentTestD2V2(ComponentTestB):
+    param_dict: dict = field(default_factory=dict)
+
+    def execute(self) -> None:
+        pass

--- a/ml_orchestrator/comp_parser.py
+++ b/ml_orchestrator/comp_parser.py
@@ -4,7 +4,7 @@ from typing import List
 from ml_orchestrator.comp_protocol.comp_protocol import ComponentProtocol
 from ml_orchestrator.comp_protocol.func_parser import FunctionParser
 from ml_orchestrator.env_params import EnvironmentParams
-from ml_orchestrator.meta_comp import MetaComponent
+from ml_orchestrator.meta_comp import MetaComponent, MetaComponentV2
 
 
 @dataclasses.dataclass
@@ -12,8 +12,8 @@ class ComponentParser(FunctionParser):
     add_imports: List[str] = dataclasses.field(default_factory=lambda: [])
     only_function: bool = False
 
-    @staticmethod
-    def create_decorator(env: EnvironmentParams) -> str:
+    @classmethod
+    def _create_decorator(cls, env: EnvironmentParams) -> str:
         dec_vars = env.comp_vars()
         prams = ComponentParser.get_func_params(dec_vars, with_typing=False)
         override_params = ComponentParser._get_decorator_override_params(prams)
@@ -21,6 +21,10 @@ class ComponentParser(FunctionParser):
         dec_scope = ComponentParser.convert_to_format_str(dec_scope)
         func_definition = f"@component{dec_scope}"
         return func_definition
+
+    @classmethod
+    def create_decorator(cls, component: MetaComponent) -> str:
+        return cls._create_decorator(component.env)
 
     @staticmethod
     def convert_to_format_str(text: str) -> str:
@@ -32,11 +36,12 @@ class ComponentParser(FunctionParser):
     def _get_decorator_override_params(prams: List[str]) -> List[str]:
         return [p for p in prams if "None" not in p]
 
-    def create_kfp_str(self, component: MetaComponent) -> str:  # type: ignore
+    def create_kfp_str(self, component: MetaComponentV2 | MetaComponent) -> str:  # type: ignore
         function_str = super().create_kfp_str(component)  # type: ignore
         if self.only_function:
             return function_str
-        decorator_str = self.create_decorator(component.env)
+
+        decorator_str = self.create_decorator(component)  # type: ignore
         decorator_str = decorator_str.replace(" = ", "=")
         kfp_component_str = f"{decorator_str}\n{function_str}"
         kfp_component_str = kfp_component_str.replace("\t", "    ")
@@ -50,3 +55,10 @@ class ComponentParser(FunctionParser):
         for imp in self.add_imports:
             file_content = f"{imp}\n{file_content}"
         return super().write_to_file(filename, file_content)
+
+
+@dataclasses.dataclass
+class ComponentParserV2(ComponentParser):
+    @classmethod
+    def create_decorator(cls, component: MetaComponentV2) -> str:  # type: ignore
+        return cls._create_decorator(component.env())

--- a/ml_orchestrator/comp_parser.py
+++ b/ml_orchestrator/comp_parser.py
@@ -4,7 +4,7 @@ from typing import List
 from ml_orchestrator.comp_protocol.comp_protocol import ComponentProtocol
 from ml_orchestrator.comp_protocol.func_parser import FunctionParser
 from ml_orchestrator.env_params import EnvironmentParams
-from ml_orchestrator.meta_comp import MetaComponent, MetaComponentV2, _MetaComponent
+from ml_orchestrator.meta_comp import MetaComponent, _MetaComponent
 
 
 @dataclasses.dataclass
@@ -24,7 +24,9 @@ class ComponentParser(FunctionParser):
 
     @classmethod
     def create_decorator(cls, component: MetaComponent) -> str:
-        return cls._create_decorator(component.env)
+        if isinstance(component, MetaComponent):
+            return cls._create_decorator(component.env)
+        return cls._create_decorator(component.env())
 
     @staticmethod
     def convert_to_format_str(text: str) -> str:
@@ -55,10 +57,3 @@ class ComponentParser(FunctionParser):
         for imp in self.add_imports:
             file_content = f"{imp}\n{file_content}"
         return super().write_to_file(filename, file_content)
-
-
-@dataclasses.dataclass
-class ComponentParserV2(ComponentParser):
-    @classmethod
-    def create_decorator(cls, component: MetaComponentV2) -> str:  # type: ignore
-        return cls._create_decorator(component.env())

--- a/ml_orchestrator/comp_parser.py
+++ b/ml_orchestrator/comp_parser.py
@@ -4,7 +4,7 @@ from typing import List
 from ml_orchestrator.comp_protocol.comp_protocol import ComponentProtocol
 from ml_orchestrator.comp_protocol.func_parser import FunctionParser
 from ml_orchestrator.env_params import EnvironmentParams
-from ml_orchestrator.meta_comp import MetaComponent, MetaComponentV2
+from ml_orchestrator.meta_comp import MetaComponent, MetaComponentV2, _MetaComponent
 
 
 @dataclasses.dataclass
@@ -36,7 +36,7 @@ class ComponentParser(FunctionParser):
     def _get_decorator_override_params(prams: List[str]) -> List[str]:
         return [p for p in prams if "None" not in p]
 
-    def create_kfp_str(self, component: MetaComponentV2 | MetaComponent) -> str:  # type: ignore
+    def create_kfp_str(self, component: _MetaComponent) -> str:  # type: ignore
         function_str = super().create_kfp_str(component)  # type: ignore
         if self.only_function:
             return function_str

--- a/ml_orchestrator/comp_protocol/func_parser.py
+++ b/ml_orchestrator/comp_protocol/func_parser.py
@@ -28,8 +28,8 @@ class FunctionParser:
     def get_function_parts(self, comp_class: Type[ComponentProtocol]) -> Tuple[str, str]:
         component_variables = self.comp_vars(comp_class)
         kfp_func_name = comp_class.__name__.lower()
-        func_scope = "(\n\t" + ",\n\t".join(self.get_func_params(component_variables)) + "\n)"
-        comp_scope = "(\n\t\t" + ",\n\t\t".join(self.get_comp_params(component_variables)) + "\n\t)"
+        func_scope = "(\n\t" + ",\n\t".join(self.get_func_params(component_variables)) + ",\n)"
+        comp_scope = "(\n\t\t" + ",\n\t\t".join(self.get_comp_params(component_variables)) + ",\n\t)"
         return_type = ""
         if self.exe_return(comp_class) is not None:
             return_type = f" -> {self.exe_return(comp_class).__name__}"

--- a/ml_orchestrator/meta_comp.py
+++ b/ml_orchestrator/meta_comp.py
@@ -6,7 +6,7 @@ from ml_orchestrator.env_params import EnvironmentParams
 
 
 @dataclasses.dataclass
-class MetaComponent(abc.ABC):
+class _MetaComponent(abc.ABC):
     @abc.abstractmethod
     def execute(
         self,
@@ -24,6 +24,20 @@ class MetaComponent(abc.ABC):
 
         return ins_vars
 
+
+@dataclasses.dataclass
+class MetaComponent(_MetaComponent):
     @property
     def env(self) -> EnvironmentParams:
+        return EnvironmentParams()
+
+    @classmethod
+    def kfp_func_name(cls) -> str:
+        return cls.__name__.lower()
+
+
+@dataclasses.dataclass
+class MetaComponentV2(_MetaComponent):
+    @classmethod
+    def env(cls) -> EnvironmentParams:
         return EnvironmentParams()

--- a/ml_orchestrator/meta_comp.py
+++ b/ml_orchestrator/meta_comp.py
@@ -39,5 +39,6 @@ class MetaComponent(_MetaComponent):
 @dataclasses.dataclass
 class MetaComponentV2(_MetaComponent):
     @classmethod
+    @abc.abstractmethod
     def env(cls) -> EnvironmentParams:
         return EnvironmentParams()

--- a/ml_orchestrator/meta_comp.py
+++ b/ml_orchestrator/meta_comp.py
@@ -40,5 +40,4 @@ class MetaComponent(_MetaComponent):
 class MetaComponentV2(_MetaComponent):
     @classmethod
     @abc.abstractmethod
-    def env(cls) -> EnvironmentParams:
-        return EnvironmentParams()
+    def env(cls) -> EnvironmentParams: ...

--- a/poetry.lock
+++ b/poetry.lock
@@ -1040,29 +1040,29 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruff"
-version = "0.8.3"
+version = "0.8.4"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.8.3-py3-none-linux_armv6l.whl", hash = "sha256:8d5d273ffffff0acd3db5bf626d4b131aa5a5ada1276126231c4174543ce20d6"},
-    {file = "ruff-0.8.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4d66a21de39f15c9757d00c50c8cdd20ac84f55684ca56def7891a025d7e939"},
-    {file = "ruff-0.8.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c356e770811858bd20832af696ff6c7e884701115094f427b64b25093d6d932d"},
-    {file = "ruff-0.8.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c0a60a825e3e177116c84009d5ebaa90cf40dfab56e1358d1df4e29a9a14b13"},
-    {file = "ruff-0.8.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75fb782f4db39501210ac093c79c3de581d306624575eddd7e4e13747e61ba18"},
-    {file = "ruff-0.8.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7f26bc76a133ecb09a38b7868737eded6941b70a6d34ef53a4027e83913b6502"},
-    {file = "ruff-0.8.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:01b14b2f72a37390c1b13477c1c02d53184f728be2f3ffc3ace5b44e9e87b90d"},
-    {file = "ruff-0.8.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53babd6e63e31f4e96ec95ea0d962298f9f0d9cc5990a1bbb023a6baf2503a82"},
-    {file = "ruff-0.8.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1ae441ce4cf925b7f363d33cd6570c51435972d697e3e58928973994e56e1452"},
-    {file = "ruff-0.8.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7c65bc0cadce32255e93c57d57ecc2cca23149edd52714c0c5d6fa11ec328cd"},
-    {file = "ruff-0.8.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5be450bb18f23f0edc5a4e5585c17a56ba88920d598f04a06bd9fd76d324cb20"},
-    {file = "ruff-0.8.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8faeae3827eaa77f5721f09b9472a18c749139c891dbc17f45e72d8f2ca1f8fc"},
-    {file = "ruff-0.8.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:db503486e1cf074b9808403991663e4277f5c664d3fe237ee0d994d1305bb060"},
-    {file = "ruff-0.8.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6567be9fb62fbd7a099209257fef4ad2c3153b60579818b31a23c886ed4147ea"},
-    {file = "ruff-0.8.3-py3-none-win32.whl", hash = "sha256:19048f2f878f3ee4583fc6cb23fb636e48c2635e30fb2022b3a1cd293402f964"},
-    {file = "ruff-0.8.3-py3-none-win_amd64.whl", hash = "sha256:f7df94f57d7418fa7c3ffb650757e0c2b96cf2501a0b192c18e4fb5571dfada9"},
-    {file = "ruff-0.8.3-py3-none-win_arm64.whl", hash = "sha256:fe2756edf68ea79707c8d68b78ca9a58ed9af22e430430491ee03e718b5e4936"},
-    {file = "ruff-0.8.3.tar.gz", hash = "sha256:5e7558304353b84279042fc584a4f4cb8a07ae79b2bf3da1a7551d960b5626d3"},
+    {file = "ruff-0.8.4-py3-none-linux_armv6l.whl", hash = "sha256:58072f0c06080276804c6a4e21a9045a706584a958e644353603d36ca1eb8a60"},
+    {file = "ruff-0.8.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ffb60904651c00a1e0b8df594591770018a0f04587f7deeb3838344fe3adabac"},
+    {file = "ruff-0.8.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ddf5d654ac0d44389f6bf05cee4caeefc3132a64b58ea46738111d687352296"},
+    {file = "ruff-0.8.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e248b1f0fa2749edd3350a2a342b67b43a2627434c059a063418e3d375cfe643"},
+    {file = "ruff-0.8.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf197b98ed86e417412ee3b6c893f44c8864f816451441483253d5ff22c0e81e"},
+    {file = "ruff-0.8.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c41319b85faa3aadd4d30cb1cffdd9ac6b89704ff79f7664b853785b48eccdf3"},
+    {file = "ruff-0.8.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:9f8402b7c4f96463f135e936d9ab77b65711fcd5d72e5d67597b543bbb43cf3f"},
+    {file = "ruff-0.8.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e4e56b3baa9c23d324ead112a4fdf20db9a3f8f29eeabff1355114dd96014604"},
+    {file = "ruff-0.8.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:736272574e97157f7edbbb43b1d046125fce9e7d8d583d5d65d0c9bf2c15addf"},
+    {file = "ruff-0.8.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fe710ab6061592521f902fca7ebcb9fabd27bc7c57c764298b1c1f15fff720"},
+    {file = "ruff-0.8.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:13e9ec6d6b55f6da412d59953d65d66e760d583dd3c1c72bf1f26435b5bfdbae"},
+    {file = "ruff-0.8.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:97d9aefef725348ad77d6db98b726cfdb075a40b936c7984088804dfd38268a7"},
+    {file = "ruff-0.8.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ab78e33325a6f5374e04c2ab924a3367d69a0da36f8c9cb6b894a62017506111"},
+    {file = "ruff-0.8.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8ef06f66f4a05c3ddbc9121a8b0cecccd92c5bf3dd43b5472ffe40b8ca10f0f8"},
+    {file = "ruff-0.8.4-py3-none-win32.whl", hash = "sha256:552fb6d861320958ca5e15f28b20a3d071aa83b93caee33a87b471f99a6c0835"},
+    {file = "ruff-0.8.4-py3-none-win_amd64.whl", hash = "sha256:f21a1143776f8656d7f364bd264a9d60f01b7f52243fbe90e7670c0dfe0cf65d"},
+    {file = "ruff-0.8.4-py3-none-win_arm64.whl", hash = "sha256:9183dd615d8df50defa8b1d9a074053891ba39025cf5ae88e8bcb52edcc4bf08"},
+    {file = "ruff-0.8.4.tar.gz", hash = "sha256:0d5f89f254836799af1615798caa5f80b7f935d7a670fad66c5007928e57ace8"},
 ]
 
 [[package]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,25 +3,8 @@ from pathlib import Path
 
 import pytest
 
-import dummy_components.dummy_components as dcomps
-import dummy_components.protocol_components as pcomps
 from ml_orchestrator import ComponentParser
 from ml_orchestrator.comp_protocol.func_parser import FunctionParser
-
-valid_classes = [
-    dcomps.ComponentTestB,
-    dcomps.ComponentTestA,
-    dcomps.ComponentTestC,
-    dcomps.ComponentTestC2,
-    dcomps.ComponentTestC3,
-    dcomps.ComponentTestD,
-    dcomps.ComponentTestD2,
-    pcomps.ComponentTestB,
-    pcomps.ComponentTestA,
-    pcomps.ComponentTestC,
-    pcomps.ComponentTestC2,
-    pcomps.ComponentTestC3,
-]
 
 
 @pytest.fixture(params=[True, False])

--- a/tests/test_dummies/conftest.py
+++ b/tests/test_dummies/conftest.py
@@ -1,7 +1,12 @@
 import pytest
 
-from dummy_components import invalid_protocol_components as ipcomps, protocol_components as pcomps
-from tests.conftest import valid_classes
+from dummy_components import (
+    invalid_classes_protocols,
+    protocol_components as pcomps,
+    valid_classes,
+    valid_classes_meta,
+    valid_classes_meta_v2,
+)
 
 
 @pytest.fixture(params=valid_classes)
@@ -20,7 +25,7 @@ def dummy_component_class(request):
     return request.param
 
 
-@pytest.fixture(params=[ipcomps.ComponentTestB, ipcomps.ComponentTestA])
+@pytest.fixture(params=invalid_classes_protocols)
 def dummy_invalid_component_class(request):
     return request.param
 
@@ -28,3 +33,18 @@ def dummy_invalid_component_class(request):
 @pytest.fixture
 def dummy_component(dummy_component_class_):
     return dummy_component_class_()
+
+
+# @pytest.fixture(params=valid_classes_meta)
+# def dummy_meta_classes_v1(request):
+#     return request.param
+#
+#
+# @pytest.fixture(params=valid_classes_meta_v2)
+# def dummy_meta_classes_v2(request):
+#     return request.param
+
+
+@pytest.fixture(params=valid_classes_meta + valid_classes_meta_v2)
+def dummy_meta_classes_all(request):
+    return request.param

--- a/tests/test_dummies/test_dec.py
+++ b/tests/test_dummies/test_dec.py
@@ -1,0 +1,25 @@
+from ml_orchestrator import ComponentParser
+from ml_orchestrator.meta_comp import MetaComponentV2
+
+
+def test_create_kfp_decorator(dummy_meta_classes_all):
+    op_dec = ComponentParser()
+    if issubclass(dummy_meta_classes_all, MetaComponentV2):
+        ob_to_check = dummy_meta_classes_all
+        env_ob = ob_to_check.env().__dict__
+    else:
+        ob_to_check = dummy_meta_classes_all()
+        env_ob = ob_to_check.env.__dict__
+    dec_str = op_dec.create_decorator(ob_to_check)
+
+    assert "@component" in dec_str
+    assert "base_image" in dec_str if env_ob["base_image"] is not None else True
+    assert "install_kfp_package" in dec_str if env_ob["install_kfp_package"] is not None else True
+    assert "packages_to_install" in dec_str if env_ob["packages_to_install"] is not None else True
+    assert "pip_index_urls" in dec_str if env_ob["pip_index_urls"] is not None else True
+    assert "target_image" in dec_str if env_ob["target_image"] is not None else True
+    assert "kfp_package_path" in dec_str if env_ob["kfp_package_path"] is not None else True
+    assert ":" not in dec_str
+    assert "(" in dec_str
+    assert ")" in dec_str
+    assert "None" not in dec_str

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -45,13 +45,13 @@ def test_fun_op(only_function):
 
 
 def test_dec_op():
-    str_func = ComponentParser.create_decorator(EnvironmentParams())
+    str_func = ComponentParser._create_decorator(EnvironmentParams())
 
     assert "None" not in str_func
     assert "@component" in str_func
     assert "(\n\t\n)" in str_func
 
-    str_func = ComponentParser.create_decorator(EnvironmentParams(**params))
+    str_func = ComponentParser._create_decorator(EnvironmentParams(**params))
 
     assert "(\n\t\n)" not in str_func and "()" not in str_func
     assert "None" not in str_func


### PR DESCRIPTION
Revised `ComponentParser` and `MetaComponent` structure to improve maintainability and introduced support for `MetaComponentV2`. Updated `ruff` dependency to version 0.8.4, added `mypy` target to the `Makefile`, and switched GitHub workflow to `make` for uniform task execution.